### PR TITLE
Workaround to have working extraction for ROOT > 6.26

### DIFF
--- a/analyse_tree.py
+++ b/analyse_tree.py
@@ -17,19 +17,22 @@ args = parser.parse_args()
 
 # initialise parameters from parser (can be overwritten by external yaml file)
 
-if args.config_file != "":
-    config_file = open(args.config_file, 'r')
-    config = yaml.full_load(config_file)
-    mc = config['mc']
-    input_files_name = config['input_files']
-    output_dir_name = config['output_dir']
-    output_file_name = config['output_file']
-    selections = config['selection']
-    selections_string = utils.convert_sel_to_string(selections)
-    is_matter = config['is_matter']
-    is_h4l = config['is_h4l']
-    skip_out_tree = config['skip_out_tree']
-    calibrate_he_momentum = config['calibrate_he_momentum']
+if args.config_file == "":
+    print('** No config file provided. Exiting. **')
+    exit()
+
+config_file = open(args.config_file, 'r')
+config = yaml.full_load(config_file)
+mc = config['mc']
+input_files_name = config['input_files']
+output_dir_name = config['output_dir']
+output_file_name = config['output_file']
+selections = config['selection']
+selections_string = utils.convert_sel_to_string(selections)
+is_matter = config['is_matter']
+is_h4l = config['is_h4l']
+skip_out_tree = config['skip_out_tree']
+calibrate_he_momentum = config['calibrate_he_momentum']
 
 
 matter_options = ['matter', 'antimatter', 'both']
@@ -82,7 +85,7 @@ hHeliumPIDHypo = ROOT.TH1F("hHeliumPIDHypo", "; Hypothesis", 16, 0.5, 16.5)
 hPiPIDHypo = ROOT.TH1F("hPiPIDHypo", "; Hypothesis", 16, 0.5, 16.5)
 
 ############# Read trees #############
-tree_names = ['O2datahypcands','O2hypcands', 'O2hypcandsflow', 'O2mchypcands', 'O2hypcandsflow;11']
+tree_names = ['O2datahypcands','O2hypcands', 'O2hypcandsflow', 'O2mchypcands']
 tree_keys = uproot.open(input_files_name[0]).keys()
 for tree in tree_names:
     for key in tree_keys:

--- a/ct_analysis.py
+++ b/ct_analysis.py
@@ -59,7 +59,15 @@ if __name__ == '__main__':
     print("----------------------------------")
     print("** Loading data and apply preselections **")
 
-    data_hdl = TreeHandler(input_file_name_data, 'O2datahypcands')
+    tree_names = ['O2datahypcands','O2hypcands', 'O2hypcandsflow']
+    tree_keys = uproot.open(input_file_name_data[0]).keys()
+    for tree in tree_names:
+        for key in tree_keys:
+            if tree in key:
+                tree_name = key
+                break
+    print(f"Data tree found: {tree_name}")
+    data_hdl = TreeHandler(input_file_name_data, tree_name)
     mc_hdl = TreeHandler(input_file_name_mc, 'O2mchypcands', folder_name='DF')
 
     lifetime_dist = ROOT.TH1D('syst_lifetime', ';#tau ps ;Counts', 40, 120, 380)
@@ -94,7 +102,6 @@ if __name__ == '__main__':
     utils.reweight_pt_spectrum(mc_hdl, 'fAbsGenPt', he3_spectrum)
 
     mc_hdl.apply_preselections('rej==True')
-    mc_hdl.apply_preselections('fGenCt < 28.5 or fGenCt > 28.6') ### Needed to remove the peak at 28.5 cm in the anchored MC
     mc_reco_hdl = mc_hdl.apply_preselections('fIsReco == 1', inplace=False)
 
     print("** Data loaded. ** \n")

--- a/pt_analysis.py
+++ b/pt_analysis.py
@@ -59,7 +59,15 @@ if __name__ == '__main__':
     print("----------------------------------")
     print("** Loading data and apply preselections **")
 
-    data_hdl = TreeHandler(input_file_name_data, 'O2datahypcands')
+    tree_names = ['O2datahypcands','O2hypcands', 'O2hypcandsflow']
+    tree_keys = uproot.open(input_file_name_data[0]).keys()
+    for tree in tree_names:
+        for key in tree_keys:
+            if tree in key:
+                tree_name = key
+                break
+    print(f"Data tree found: {tree_name}")
+    data_hdl = TreeHandler(input_file_name_data, tree_name)
     mc_hdl = TreeHandler(input_file_name_mc, 'O2mchypcands', folder_name='DF')
 
     # declare output file
@@ -90,12 +98,8 @@ if __name__ == '__main__':
     he3_spectrum = spectra_file.Get('fCombineHeliumSpecLevyFit_0-100')
     spectra_file.Close()
     utils.reweight_pt_spectrum(mc_hdl, 'fAbsGenPt', he3_spectrum)
-
     mc_hdl.apply_preselections('rej==True')
     mc_reco_hdl = mc_hdl.apply_preselections('fIsReco == 1', inplace=False)
-    
-    print("reco hdl len: ", len(mc_reco_hdl))
-    print("mc hdl len: ", len(mc_hdl))
 
     print("** Data loaded. ** \n")
     print("----------------------------------")
@@ -171,9 +175,10 @@ if __name__ == '__main__':
 
     print("** pt analysis done. ** \n")
 
-    print("** Starting systematic variations **")
+    
 
     if do_syst:
+        print("** Starting systematic variations **")
         n_trials = config['n_trials']
         output_dir_syst = output_file.mkdir('trials')
         # list of trial strings to be printed to a text file

--- a/spectra.py
+++ b/spectra.py
@@ -127,14 +127,11 @@ class SpectraMaker:
             signal_extraction.matter_type = self.is_matter
             signal_extraction.performance = False
             signal_extraction.is_3lh = True
-
-            if isinstance(self.sigma_range_mc_to_data[0], list):
-                signal_extraction.sigma_range_mc_to_data = self.sigma_range_mc_to_data[ibin]
-            else:
-                signal_extraction.sigma_range_mc_to_data = self.sigma_range_mc_to_data
-
-            fit_stats = signal_extraction.process_fit()
-
+            
+            signal_extraction.out_file = self.output_dir
+            signal_extraction.data_frame_fit_name = f'data_fit_{ibin}'
+            signal_extraction.mc_frame_fit_name = f'mc_fit_{ibin}'
+            
             if self.var == 'fPt':
                 bin_label = f'{bin[0]} #leq #it{{p}}_{{T}} < {bin[1]} GeV/#it{{c}}'
             else:
@@ -142,9 +139,13 @@ class SpectraMaker:
 
             signal_extraction.additional_pave_text = bin_label
 
-            self.h_signal_extractions_data.append(
-                signal_extraction.data_frame_fit)
-            self.h_signal_extractions_mc.append(signal_extraction.mc_frame_fit)
+            if isinstance(self.sigma_range_mc_to_data[0], list):
+                signal_extraction.sigma_range_mc_to_data = self.sigma_range_mc_to_data[ibin]
+            else:
+                signal_extraction.sigma_range_mc_to_data = self.sigma_range_mc_to_data
+
+            fit_stats = signal_extraction.process_fit()
+            
             self.raw_counts.append(fit_stats['signal'][0])
             self.raw_counts_err.append(fit_stats['signal'][1])
             self.chi2.append(fit_stats['chi2'])
@@ -227,8 +228,7 @@ class SpectraMaker:
         self.efficiency = []
         self.corrected_counts = []
         self.corrected_counts_err = []
-        self.h_signal_extractions_data = []
-        self.h_signal_extractions_mc = []
+
 
         self.h_raw_counts = None
         self.h_efficiency = None
@@ -239,18 +239,6 @@ class SpectraMaker:
         self.h_raw_counts.Write()
         self.h_efficiency.Write()
         self.h_corrected_counts.Write()
-        for ibin in range(0, len(self.bins) - 1):
-            bin = [self.bins[ibin], self.bins[ibin + 1]]
-            self.output_dir.mkdir(f'{self.var}_{bin[0]}_{bin[1]}')
-            self.output_dir.cd(f'{self.var}_{bin[0]}_{bin[1]}')
-            h_data = self.h_signal_extractions_data[ibin]
-            h_mc = self.h_signal_extractions_mc[ibin]
-            bin_string_data = f'{self.var}_{self.bins[ibin]}_{self.bins[ibin + 1]}_data'
-            bin_string_mc = f'{self.var}_{self.bins[ibin]}_{self.bins[ibin + 1]}_mc'
-            h_data.SetName(bin_string_data)
-            h_mc.SetName(bin_string_mc)
-            h_data.Write()
-            h_mc.Write()
 
     def chi2_selection(self):
         for el in self.chi2:


### PR DESCRIPTION
Saving output objects outside the process_fit function causes a ROOT crash. Will open a ticket for this, in the meanwhile we can save the RooPlots within the same function